### PR TITLE
README: use the 3.3v rail of the nRF9160dk

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ model.
 
 | Function | Arducam Pin | nRF9160DK |  esp32  |  mimxrt1024_evk |
 | -------- | ----------- | --------- |  ------ |  -------------- |
-| VCC      | 1 (red)     | 5V        |  3.3V   |  3.3V  (J20.08) |
+| VCC      | 1 (red)     | VDD[^1]   |  3.3V   |  3.3V  (J20.08) |
 | GND      | 2 (black)   | GND       |  GND    |  GND   (J20.12) |
 | CS       | 6 (orange)  | P0.10     |  GPIO15 |  b1_13 (J18.08) |
 | MOSI     | 5 (yellow)  | P0.11     |  GPIO13 |  b1_14 (J18.12) |
 | MISO     | 4 (brown)   | P0.12     |  GPIO12 |  b1_15 (J18.10) |
 | SCK      | 3 (white)   | P0.13     |  GPIO27 |  b1_12 (J18.06) |
+
+[^1]: For the nRF9160DK, change the `VDD IO` switch (near the power
+    switch) to `3V`.
 
 ### ESP32 Extra Setup
 

--- a/src/main.c
+++ b/src/main.c
@@ -139,11 +139,6 @@ static enum golioth_status block_upload_read_chunk(uint32_t block_idx,
         *block_size = bu_size;
         *is_last = true;
     }
-    else
-    {
-        *block_size = bu_max_block_size;
-        *is_last = false;
-    }
 
     memcpy(block_buffer, bu_source->buf + bu_offset, *block_size);
     return GOLIOTH_OK;


### PR DESCRIPTION
- Change the pinout diagram and add a footnote about using the 3V setting on the nRF9160dk.
- Remove a redundant variable assignment in the block write callback